### PR TITLE
chore: Update aptos to aptos-cli-v0.3.9

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-wallet-v1.0.0
+aptos-cli-v0.3.9


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is wallet-v1.0.0 and the current head is
has been changed to aptos-cli-v0.3.9.