### PR TITLE
chore: Update agoric-ag0 to agoric-upgrade-7-2

### DIFF
--- a/agoric-ag0/VERSION
+++ b/agoric-ag0/VERSION
@@ -1,1 +1,1 @@
-agoric-upgrade-7
+agoric-upgrade-7-2


### PR DESCRIPTION
Automated update for agoric-ag0.

The found in repo version is agoric-upgrade-7 and the current head is
has been changed to agoric-upgrade-7-2.