### PR TITLE
chore: Update aptos to aptos-cli-v0.4.0

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-cli-v0.3.9
+aptos-cli-v0.4.0


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is aptos-cli-v0.3.9 and the current head is
has been changed to aptos-cli-v0.4.0.