### PR TITLE
chore: Update penumbra to 032-chaldene.1

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,1 +1,1 @@
-031-autonoe
+032-chaldene.1


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 031-autonoe and the current head is
has been changed to 032-chaldene.1.