### PR TITLE
chore: Update penumbra to 033-eirene

### DIFF
--- a/penumbra/VERSION
+++ b/penumbra/VERSION
@@ -1,1 +1,1 @@
-032-chaldene.1
+033-eirene


### PR DESCRIPTION
Automated update for penumbra.

The found in repo version is 032-chaldene.1 and the current head is
has been changed to 033-eirene.