### PR TITLE
chore: Update cosmovisor to tools/cosmovisor/v1.4.0

### DIFF
--- a/.github/workflows/matrix-run.yaml
+++ b/.github/workflows/matrix-run.yaml
@@ -194,7 +194,7 @@ jobs:
           draft: false
           prerelease: false
           fail_on_unmatched_files: false
-          tag_name: ${{ matrix.version }}-${{ github.ref }}-${{ steps.targettag.outputs.value }}
+          tag_name: ${{ matrix.version }}-${{ steps.refsha.outputs.value }}
           name: ${{ matrix.base }} build release for ${{ matrix.version }} on ${{ steps.targettag.outputs.value }}
           body: |
             Build release for ${{ matrix.base }} version ${{ matrix.version }}.

--- a/cosmovisor/Dockerfile
+++ b/cosmovisor/Dockerfile
@@ -4,6 +4,8 @@ ARG git_version=main
 RUN git clone --recursive --branch $git_version $git_repository /build_dir
 WORKDIR /build_dir
 RUN make cosmovisor
+WORKDIR /build_dir/cosmovisor
+RUN if [ -f /build_dir/tools/cosmovisor/cosmovisor ]; then cp /build_dir/tools/cosmovisor/cosmovisor /build_dir/cosmovisor/cosmovisor; fi
 
 FROM gcr.io/distroless/base-debian11:latest
 ARG git_repository=https://github.com/cosmos/cosmos-sdk

--- a/cosmovisor/VERSION
+++ b/cosmovisor/VERSION
@@ -1,2 +1,1 @@
-v0.45.10
-
+tools/cosmovisor/v1.4.0


### PR DESCRIPTION
Automated update for cosmovisor.

The found in repo version is v0.45.10 and the current head is
has been changed to tools/cosmovisor/v1.4.0.