### PR TITLE
chore: Update agoric to mainnet1B-rc3

### DIFF
--- a/agoric/VERSION
+++ b/agoric/VERSION
@@ -1,1 +1,1 @@
-pismoC
+mainnet1B-rc3


### PR DESCRIPTION
Automated update for agoric.

The found in repo version is pismoC and the current head is
has been changed to mainnet1B-rc3.