### PR TITLE
chore: Update cosmovisor to cosmovisor/v1.5.0

### DIFF
--- a/cosmovisor/VERSION
+++ b/cosmovisor/VERSION
@@ -1,1 +1,1 @@
-v0.47.3
+cosmovisor/v1.5.0


### PR DESCRIPTION
Automated update for cosmovisor.

The found in repo version is v0.47.3 and the current head is
has been changed to cosmovisor/v1.5.0.