### PR TITLE
chore: Update sui to mainnet-v1.8.2

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-devnet-v1.1.0
+mainnet-v1.8.2


### PR DESCRIPTION
Automated update for sui.

The found in repo version is devnet-v1.1.0 and the current head is
has been changed to mainnet-v1.8.2.