### PR TITLE
chore: Update agoric to agoric-upgrade-11

### DIFF
--- a/agoric/VERSION
+++ b/agoric/VERSION
@@ -1,1 +1,1 @@
-pismoC
+agoric-upgrade-11


### PR DESCRIPTION
Automated update for agoric.

The found in repo version is pismoC and the current head is
has been changed to agoric-upgrade-11.