### PR TITLE
chore: Update aptos to aptos-node-v1.6.3

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-adhoc_20230829
+aptos-node-v1.6.3


### PR DESCRIPTION
Automated update for aptos.

The found in repo version is adhoc_20230829 and the current head is
has been changed to aptos-node-v1.6.3.